### PR TITLE
Upgrade to coverage 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = '\n\n'.join([
 
 install_requires = [
     'setuptools',
-    'coverage >= 3.4',
+    'coverage >= 3.6',
     ],
 
 tests_require = [


### PR DESCRIPTION
# The problem

We currently have a version conflict between createcoverage and coveralls (https://pypi.python.org/pypi/coveralls).

When we run our tests on Travis, we use the createcoverage dependencies when running the tests themselves (so coverage 3.4 at the moment), but the typical `after_success`:

```
after_success:
  - pip install coveralls
  - coveralls
```

does not find a satisfying coverage version (>=3.6 as requested by coveralls) and installs its own coverage version (4.0.2) which is not compliant with the 3.4 output file, and nothing is sent to Coveralls.io:

```
Submitting coverage to coveralls.io...
Coverage submitted!
Failure to gather coverage: Couldn't read data from '/home/travis/build/plomino/rapido.core/.coverage': CoverageException: Doesn't seem to be a coverage.py data file
'url'
```

(which is not the most brilliant error message I have read, the "Coverage submitted!" is misleading).
# Proposed solution

Upgrading to 3.6 does not seem to break anything, and it is compliant with the current version of coveralls.

Note: coverage 4.0 does break `bin/coverage`, I haven't checked why.
# Usage with buildout

This PR does not fix the all thing when we use buildout, as the buildout eggs won't be considered by the `pip install` command, so coverage 4.0 will be installed, so when we use buildout we need to fix our `travis.cfg` file like this:

```
after_success:
  - pip install coverage==3.6 coveralls
  - coveralls
```
